### PR TITLE
Update 2015-03-17-spring.md - application must extend from ControllerApplication

### DIFF
--- a/_posts/2015-03-17-spring.md
+++ b/_posts/2015-03-17-spring.md
@@ -29,10 +29,10 @@ public class ContactsController extends Controller {
 
 Pippo automatically creates the _ContactsController_ instance and pippo-spring injects the ContactService service bean, so basically you don’t have to worry about any of that stuff. 
 
-To activate pippo-spring integration in your Application you must add `SpringControllerFactory`:
+To activate pippo-spring integration in your Application you must register `SpringControllerFactory` and extend from `ControllerApplication` instead:
 
 ```java
-public class MyApplication extends Application {
+public class MyApplication extends ControllerApplication {
 
     @Override
     protected void onInit() {


### PR DESCRIPTION
Change docs to specify that to be able to set custom SpringControllerFactory the application must extend from ControllerApplication